### PR TITLE
[CircleCI] Add dependencies install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,6 @@ jobs:
       - image: circleci/ruby:2.6.3
     steps:
       - checkout
-      - run: echo "Youpi ! On est dans la première étape de l'installation de notre CI :)"
+      - run:
+          name: Install project dependencies
+          command: bin/install


### PR DESCRIPTION
## Description

Dans cette étape, on change la simple commande `echo` avec notre script `bin/install`. Cette commande permet d'installer toutes les dépendances de notre projet sur l'instance Docker sur CircleCI.