### PR TITLE
[CircleCI] Add test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,6 @@ jobs:
       - run:
           name: Install project dependencies
           command: bin/install
+      - run:
+          name: Test the project
+          command: bundle exec rspec hello_world_spec.rb


### PR DESCRIPTION
## Description

Dans cette étape, on ajoute une commande supplémentaire pour permettre de lancer les tests de notre projet sur l'instance Docker de CircleCI après l'installation des dépendances.