### PR TITLE
[CircleCI] Use workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,18 @@ jobs:
           key: bundler-{{ checksum "Gemfile.lock" }}
           paths:
             - /usr/local/bundle
+      - persist_to_workspace:
+          root: /usr/local
+          paths:
+            - bundle
+
   test:
     docker:
       - image: circleci/ruby:2.6.3
     steps:
       - checkout
+      - attach_workspace:
+          at: /usr/local
       - run:
           name: Test the project
           command: bundle exec rspec hello_world_spec.rb


### PR DESCRIPTION
## Description

Dans cette étape, nous allons ajouter l'utilisation des [workspaces](https://circleci.com/docs/2.0/concepts/#workspaces-and-artifacts) pour permettre de partager des données entre jobs d'un même workflow.

## Ressources 

- [Workspaces on CircleCI](https://circleci.com/docs/2.0/concepts/#workspaces-and-artifacts)
- [Deep diving into CircleCI workspaces](https://circleci.com/blog/deep-diving-into-circleci-workspaces/)