### PR TITLE
[CircleCI] Use environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.6.3
+    environment:
+      BUNDLE_PATH: vendor/bundle
+
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Description

Dans cette étape, on ajoute une variable d'environnement dans le container qui fait tourner notre job. 

## Explication

La variable `BUNDLE_PATH` permet à Bundler de savoir où enregistrer les gems qu'il télécharge. Au lieu de se fier au chemin par défaut de Bundler, qui pourrait changer d'une version à l'autre, on lui spécifie un chemin. Cela permet de rendre notre intégration plus robuste.