### PR TITLE
[CircleCI] Use workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
       - image: circleci/ruby:2.6.3
     environment:
       BUNDLE_PATH: vendor/bundle
-
     steps:
       - checkout
       - restore_cache:
@@ -13,10 +12,26 @@ jobs:
       - run:
           name: Install project dependencies
           command: bin/install
-      - run:
-          name: Test the project
-          command: bundle exec rspec hello_world_spec.rb
       - save_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+  test:
+    docker:
+      - image: circleci/ruby:2.6.3
+    environment:
+      BUNDLE_PATH: vendor/bundle
+    steps:
+      - checkout
+      - run:
+          name: Test the project
+          command: bundle exec rspec hello_world_spec.rb
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build


### PR DESCRIPTION
## Description

Dans cette étape, on organise les étapes de notre CI dans un workflow avec 2 jobs différents : 
- un pour l'installation des dépendances
- un pour le lancement des tests.

## Explication

En fonction des cas, le découpage des étapes en plusieurs jobs peut aider à : 
- lancer des jobs en parallèle : par exemple, lancer des tests front et des tests back en même temps,
- réutiliser la description d'un job dans un autre workflow dans le cas où plusieurs workflows sont lancés.

## Ressources

- [Workflows on CircleCI](https://circleci.com/docs/2.0/concepts/#workflows)